### PR TITLE
Add session to get_detailed_comment function.

### DIFF
--- a/src/bitbucket.py
+++ b/src/bitbucket.py
@@ -95,4 +95,4 @@ class BitbucketExport:
         return activity
 
     def get_detailed_comment(self, shallow_comment):
-        return get_request_json(shallow_comment["links"]["self"]["href"])
+        return get_request_json(shallow_comment["links"]["self"]["href"], self.session)


### PR DESCRIPTION
With BB private repositories, many comments aren't migrate because the function don't have the session.