### PR TITLE
Fix typo: "Marge" -> "Merge"

### DIFF
--- a/migrate-discussions.py
+++ b/migrate-discussions.py
@@ -492,7 +492,7 @@ def construct_gpull_request_body(bpull, bexport, cmap, args):
         merge_bhash = bpull["merge_commit"]["hash"]
         merge_grepo = map_brepo_to_grepo(merge_brepo)
         merge_ghash = cmap.convert_commit_hash(merge_bhash)
-        sb.append("> Marge commit: https://github.com/{grepo}/commit/{ghash}\n".format(
+        sb.append("> Merge commit: https://github.com/{grepo}/commit/{ghash}\n".format(
             grepo=merge_grepo,
             ghash=merge_ghash
         ))


### PR DESCRIPTION
This is a minor fix for a spelling error in the message produced when migrating comments - it says "Marge commit" when it should actually say "Merge commit":

![screenshot showing misspelling in "Merge commit" message](https://user-images.githubusercontent.com/17579442/131048719-8039f9b9-7079-425d-a842-7119d7764a18.png)


